### PR TITLE
Added route for retrieving a QR code for check ins

### DIFF
--- a/lib/controllers/routes/pureCloud.js
+++ b/lib/controllers/routes/pureCloud.js
@@ -6,9 +6,12 @@ var router = express.Router();
 
 var PureCloudAPIService = require("../../services/PureCloudAPIService");
 var SessionStoreService = require("../../services/SessionStoreService");
+var QRCodeGenerator = require("../../services/QRCodeGenerator");
 var authMiddleware = require("../middleware/authToken");
+var redisMiddleware = require("../middleware/redisSession");
 var pureCloudService = new PureCloudAPIService();
 var sessionStoreService = new SessionStoreService();
+var qrCodeGenerator = new QRCodeGenerator();
 /**
  * This route is used for logging in users.
  *
@@ -36,7 +39,7 @@ router.use(authMiddleware);
  *
  * Full path : /purecloud/search
  **/
-router.get("/search", authMiddleware, function(req, res){
+router.get("/search", function(req, res){
   pureCloudService.searchPeople(req.access_token, req.query,
   function(error, response, body){
     if(error){
@@ -47,6 +50,18 @@ router.get("/search", authMiddleware, function(req, res){
       res.send(body);
     }
   });
+});
+
+router.use(redisMiddleware);
+/**
+ *  Get qr code using redis data
+ *
+ *  Since this qr code is generated using session data stored in the redis database,
+ *  you can't just place this in an image tag in your HTML. Make a request and place the
+ *  data from the response in the tag's src attribute.
+ **/
+router.get("/myqrcode", function(req, res){
+  qrCodeGenerator.generate(req.user.name, req.user.organization, req.user.personID).pipe(res);
 });
 
 module.exports = router;

--- a/lib/services/QRCodeGenerator.js
+++ b/lib/services/QRCodeGenerator.js
@@ -1,0 +1,25 @@
+"use strict";
+/**
+ *  QR Code Generator
+ *
+ **/
+var request = require("request");
+
+class QRCodeGenerator{
+  /**
+  * generates the qr code
+  *
+  * requires that a name, organization, personID and callback is given.
+  *
+  * the callback is like any typical request callback, it contains the error,
+  * response, and body.
+  **/
+  generate(name, organization, personID, callback){
+    console.log(name);
+    console.log(organization);
+    console.log(personID);
+    return request("https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=" +
+      name + ";" + organization + ";" + personID);
+  }
+}
+module.exports = QRCodeGenerator;


### PR DESCRIPTION
The image cannot be retrieved by just placing the url in the image tag, it actually needs to be grabbed using a request because the Auth header is required to make the request work. The user requesting the data also needs to be logged in.
